### PR TITLE
Feat/workflows

### DIFF
--- a/lib/flight-manage/cli.rb
+++ b/lib/flight-manage/cli.rb
@@ -78,9 +78,11 @@ module FlightManage
 
       def add_role_and_stage_options(command)
         command.option '-r', '--role ROLE',
-          'Run all scripts with ROLE (and no STAGE unless --stage is passed)'
+          'Select all scripts with ROLE (and no STAGE unless --stage is passed)'
         command.option '-s', '--stage STAGE',
-          'Run all scripts with STAGE (and no ROLE unless --role is passed)'
+          'Select all scripts with STAGE (and no ROLE unless --role is passed)'
+        command.option '-c', '--chain CHAIN',
+          'Select all the scripts in the specified file'
       end
     end
 

--- a/lib/flight-manage/commands/scripts/run.rb
+++ b/lib/flight-manage/commands/scripts/run.rb
@@ -91,7 +91,6 @@ Script #{script.name} cannot be re-ran or has failed on this node
 
         # print output, log & update the node's statefile
         def output_execution_data(exec_values, script, sf)
-          #TODO include dir in log??
           exit_code = exec_values['exit_code']
 
           # maybe order the script names in the yaml

--- a/lib/flight-manage/models/chain.rb
+++ b/lib/flight-manage/models/chain.rb
@@ -45,7 +45,7 @@ No chain file founnd at #{path}
         data = Utils.read_yaml(@path)
         unless data.is_a?(Array)
           raise ManageError, <<-ERROR.chomp
-Invalid chain at #{@path} - not a hyphenated list
+Invalid chain at #{@path} - not a yaml list
           ERROR
         end
         return data

--- a/lib/flight-manage/models/chain.rb
+++ b/lib/flight-manage/models/chain.rb
@@ -25,39 +25,50 @@
 # https://github.com/openflighthpc/flight-manage
 # ==============================================================================
 
-require 'flight-manage/command'
-require 'flight-manage/models/chain'
 require 'flight-manage/models/script'
-
-require 'lockfile'
+require 'flight-manage/utils'
 
 module FlightManage
-  module Commands
-    module Scripts
-      # Super class containing script selection methods
-      class ScriptCommand < Command
-        # Locate scripts from argv and stage & role options
-        # Can be used in commands without these options as they'll
-        # evaluate to nil
-        def find_scripts(validate = false)
-          if @options.chain
-            #return find_scripts_from_workflow
-            Models::Chain.new(@options.chain, @options.role).scripts
-          elsif @options.role or @options.stage
-            return Models::Script.find_scripts_with_role_and_stage(
-              @options.role,
-              @options.stage
-            )
-          elsif @argv[0]
-            script = Models::Script.new({'name' => @argv[0]})
-            script.validate if validate
-            return [script]
+  module Models
+    class Chain
+      def initialize(path, role = nil)
+        unless File.file?(path) and File.readable?(path)
+          raise ArgumentError, <<-ERROR.chomp
+No chain file founnd at #{path}
+          ERROR
+        end
+        @path = path
+        @role = role
+      end
+
+      def data
+        data = Utils.read_yaml(@path)
+        unless data.is_a?(Array)
+          raise ManageError, <<-ERROR.chomp
+Invalid chain at #{@path} - not a hyphenated list
+          ERROR
+        end
+        return data
+      end
+
+      def scripts
+        scripts = []
+        data.each do |line|
+          if line.is_a?(Hash) and line.key?('stage')
+            stage = line['stage']
+            stage_scripts = Script.find_scripts_with_role_and_stage(@role, stage)
+            scripts.concat(stage_scripts)
+          elsif line.is_a?(String) and not line =~ /\s/
+            script = Script.new({'name' => line})
+            script.validate
+            scripts << script
           else
-            raise ArgumentError, <<-ERROR.chomp
-Please provide either a script, a role, a stage, or a chain
+            raise ManageError, <<-ERROR.chomp
+Error with chain - invlid line #{line}
             ERROR
           end
         end
+        return scripts
       end
     end
   end

--- a/lib/flight-manage/models/script.rb
+++ b/lib/flight-manage/models/script.rb
@@ -48,7 +48,7 @@ module FlightManage
           return matches
         end
 
-        #TODO check whether to remove this error
+        #TODO check whether to remove this error for when running a chain
         # print error if no scripts are found
         def error_from_role_and_stage(role, stage)
           role_str = role ? "role '#{role}'" : "no role"

--- a/lib/flight-manage/models/script.rb
+++ b/lib/flight-manage/models/script.rb
@@ -34,6 +34,30 @@ module FlightManage
       attr_reader :name, :dir, :path
 
       class << self
+        # resolve role & stage options to find scripts
+        def find_scripts_with_role_and_stage(role, stage)
+          matches = []
+          glob_all_scripts.each do |script|
+            if script.stages.include?(stage)
+              if script.roles.include?(role)
+                matches << script
+              end
+            end
+          end
+          error_from_role_and_stage(role, stage) if matches.empty?
+          return matches
+        end
+
+        #TODO check whether to remove this error
+        # print error if no scripts are found
+        def error_from_role_and_stage(role, stage)
+          role_str = role ? "role '#{role}'" : "no role"
+          stage_str = stage ? "stage '#{stage}'" : "no stage"
+          raise ArgumentError, <<-ERROR.chomp
+No scripts found with #{role_str} and #{stage_str}
+          ERROR
+        end
+
         def glob_all_scripts
           # will be ordered first by script directory (as defined in the config)
           # then by the order defined below in `sort_scripts`

--- a/lib/flight-manage/models/state_file.rb
+++ b/lib/flight-manage/models/state_file.rb
@@ -26,8 +26,7 @@
 # ==============================================================================
 
 require 'flight-manage/config'
-
-require 'yaml'
+require 'flight-manage/utils'
 
 module FlightManage
   module Models
@@ -41,19 +40,7 @@ module FlightManage
       def data
         # create file if it doesn't exist
         File.open(path, 'w') {} unless File.file?(path)
-
-        data = nil
-        begin
-          File.open(path) do |f|
-            data = YAML.safe_load(f)
-          end
-        rescue Psych::SyntaxError
-          raise ParseError, <<-ERROR.chomp
-Error parsing yaml in #{location} - aborting
-          ERROR
-        end
-        data ||= {}
-        data
+        Utils.read_yaml(path)
       end
 
       def path

--- a/lib/flight-manage/utils.rb
+++ b/lib/flight-manage/utils.rb
@@ -26,6 +26,7 @@
 # ==============================================================================
 
 require 'socket'
+require 'yaml'
 
 module FlightManage
   module Utils
@@ -42,6 +43,21 @@ module FlightManage
       raise FileSysError, <<-ERROR.chomp
 The file for node #{state_file.node} is locked - aborting
       ERROR
+    end
+
+    def self.read_yaml(path)
+      data = nil
+      begin
+        File.open(path) do |f|
+          data = YAML.safe_load(f)
+        end
+      rescue Psych::SyntaxError
+        raise ManageError, <<-ERROR.chomp
+Error parsing yaml in #{path} - aborting
+        ERROR
+      end
+      data ||= {}
+      data
     end
   end
 end


### PR DESCRIPTION
Closes #11 

Add -c (chain) option to run and resolve
Takes a path to a yaml file - each script & stage in which file is
executed in order. The file must be a valid yaml list of stages and
paths & stages are specified as 'stage: STAGE'
Additionally a role can be passed with the usual '-r' (role) option - this will
make all stages then executed be executed for the specified node role.